### PR TITLE
add setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,49 @@
+
+
+[metadata]
+
+
+[options]
+zip_safe = False
+python_requires = >=3.10
+include_package_data = True
+packages = find:
+install_requires =
+    imageio >= 2.25.0
+    ipympl >= 0.9.3
+    jupyter >= 1.0.0
+    jupyterlab >= 3.6.1
+    matplotlib >= 3.3.3
+    nibabel
+    nest-asyncio >= 1.5.5
+    notebook >= 6.4.10
+    numexpr >= 2.7.3
+    numpy >= 1.22.3
+    pandas
+    pycodestyle
+    scipy >= 1.7.3
+    scikit-image >= 0.19.2
+    seaborn
+    simpleitk >= 2.2.1
+    sphinx >= 4.5.0
+    pydicom
+
+[options.data_files]
+# This section requires setuptools>=40.6.0
+# It remains empty for now
+# Check if MANIFEST.in works for your purposes
+
+[options.extras_require]
+dev =
+    bump2version
+    coverage [toml]
+    coveralls
+    isort
+    prospector[with_pyroma]
+    pytest
+    pytest-cov
+    tox
+
+[options.packages.find]
+include = cvasl, cvasl.*
+


### PR DESCRIPTION
Using this file, it's possible to run `pip install -e .` and have a working environment on wsl/ubuntu. Trying to install from environment.yml did not previously work, probably due to to memory issues.

I created this file mainly to have it locally, so I could easily create an env on ubuntu. @drcandacemakedamoore , let me know if you want to keep it in the package, and I can add metadata to the setup.cfg and add alternative installation instructions to the readme.