### PR TITLE
Premain

### DIFF
--- a/cvasl/seperated.py
+++ b/cvasl/seperated.py
@@ -12,6 +12,7 @@ files towards correct formats.
 
 import os
 import sys
+import warnings
 import pandas as pd
 from pandas.api.types import is_numeric_dtype
 import numpy as np
@@ -813,7 +814,7 @@ def stratified_one_category_shuffle_split(
         our_y,
         category='sex',
         splits=5,
-        test_size_p=0.25,
+        test_size_p=0.20,
         printed=False
 ):
     """
@@ -1004,6 +1005,9 @@ def stratified_cat_and_cont_categories_shuffle_split(
     :returns: dataframe, y dataframe, and models
     :rtype: tuple
     """
+    if test_size_p > 1 / splits :
+        message1 = "You us a potentially problematic percent (may resample) "
+        warnings.warn(message1)
     our_ml_matrix = bin_dataset(
         our_ml_matrix,
         cont_category,
@@ -1059,13 +1063,13 @@ def stratified_cat_and_cont_categories_shuffle_split(
                 y_split[train_index], return_counts=True
             )
             bins = our_ml_matrix['binned']
-            print(
-                f'Category classes: {unique_train}',
-                f'from categorical: {our_ml_matrix[cat_category].unique()} ',
-                f'and continous binned to: {bins.unique()} ',
-                f'percentages: {100*counts_train/y[train_index].shape[0]}'
-                # TODO: shape[iterates- i to fold]?
-            )
+            # print(
+            #     f'Category classes: {unique_train}',
+            #     f'from categorical: {our_ml_matrix[cat_category].unique()} ',
+            #     f'and continous binned to: {bins.unique()} ',
+            #     f'percentages: {100*counts_train/y[train_index].shape[0]}'
+            #     # TODO: shape[iterates- i to fold]?
+            # )
             print(
                 f'\nTest shapes: X {X[test_index].shape}',
                 f'  y {y[test_index].shape}'
@@ -1073,11 +1077,11 @@ def stratified_cat_and_cont_categories_shuffle_split(
             unique_test, counts_test = np.unique(
                 y_split[test_index], return_counts=True
             )
-            print(
-                f'Category classes: {unique_test},'
-                f'percentages: {100*counts_test/y[test_index].shape[0]}'
-                # TODO: shape[iterates i to fold]?
-            )
+            # print(
+            #     f'Category classes: {unique_test},'
+            #     f'percentages: {100*counts_test/y[test_index].shape[0]}'
+            #     # TODO: shape[iterates i to fold]?
+            # )
 
         data = [[
             f'{model_name}-{i}',

--- a/cvasl/seperated.py
+++ b/cvasl/seperated.py
@@ -1005,7 +1005,7 @@ def stratified_cat_and_cont_categories_shuffle_split(
     :returns: dataframe, y dataframe, and models
     :rtype: tuple
     """
-    if test_size_p > 1 / splits :
+    if test_size_p > 1 / splits:
         message1 = "You us a potentially problematic percent (may resample) "
         warnings.warn(message1)
     our_ml_matrix = bin_dataset(

--- a/extended_harm_paper/data_check.ipynb
+++ b/extended_harm_paper/data_check.ipynb
@@ -238,7 +238,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "16",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# we must discuss this with scientists"
@@ -261,8 +263,30 @@
    },
    "outputs": [],
    "source": [
-    "\n",
-    "        "
+    "negs = har.negative_harm_outcomes(\n",
+    "    'harmonizations/harm_results',\n",
+    "    'csv',\n",
+    "    number_columns=[\n",
+    "        'sex',\n",
+    "        'gm_vol',\n",
+    "        'wm_vol',\n",
+    "        'csf_vol',\n",
+    "        'gm_icvratio',\n",
+    "        'gmwm_icvratio',\n",
+    "        'wmhvol_wmvol',\n",
+    "        'wmh_count',\n",
+    "        #'deepwm_b_cov',\n",
+    "        'aca_b_cov',\n",
+    "        'mca_b_cov',\n",
+    "        'pca_b_cov',\n",
+    "        'totalgm_b_cov',\n",
+    "        #'deepwm_b_cbf',\n",
+    "        'aca_b_cbf',\n",
+    "        'mca_b_cbf',\n",
+    "        'pca_b_cbf',\n",
+    "        'totalgm_b_cbf',]\n",
+    ") \n",
+    "#negs"
    ]
   },
   {
@@ -274,26 +298,13 @@
    },
    "outputs": [],
    "source": [
-    "negs = har.negative_harm_outcomes('harmonizations/harm_results', 'csv') \n",
-    "#negs"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "20",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
     "negs"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "21",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": []


### PR DESCRIPTION
After much experimentation (on a different repo) and drama, I implemented notebook stripping on a branch called premain. This lets me leave the main protected; but if used before main, guarantees at least the main notebook outputs are stripped. As it changes the commit history between the shared and a users local repo, I will keep it only on premain for a while until any maintainer understands how to work with it. By the way it was actually implemented not on this commit, but a few back on the develop and main already (issues with how nbstrip  works). This is the workflow: https://github.com/brainspinner/cvasl/blob/main/.github/workflows/on-push-main.yml
